### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe shell command constructed from library input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export async function runCommand(
     const child = spawn(command, args, {
       cwd,
       stdio: capture ? 'pipe' : 'inherit',
-      shell: true,
     });
 
     let stdout = '';


### PR DESCRIPTION
Potential fix for [https://github.com/luthpg/gasbombe/security/code-scanning/1](https://github.com/luthpg/gasbombe/security/code-scanning/1)

The best fix is to avoid using `shell: true` whenever possible when using `spawn` with array arguments, as this bypasses argument escaping and allows the shell to interpret any special characters or metacharacters present in any element of the array. Instead:
- Remove `shell: true` from the options in the call to `spawn` unless absolutely required.
- If shell features (like pipes or redirections) are needed, form a single string command and take **extra care** to properly quote/escape inputs using a library such as `shell-quote`.
- In the context of this function, since it takes `command` and `args` separately, it should use normal child process invocation (no shell). This is far safer.
- Only conditionally use `shell: true` based on a specific, *well-audited* need, not as the default.

In this file, line 20 (`shell: true`) should be removed from the spawn options in `runCommand`.

No additional imports or complex rewrites are needed for this minimal, safest fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
