### PR TITLE
feat(cli): add skip install option and update templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciderjs/gasbombe",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A TypeScript Project Generator for GoogleAppsScript, available as CLI",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ export async function main(): Promise<void> {
     )
     .option(
       "-t, --template [templateType]",
-      'Project template label ("vanilla-ts" | "vanilla-js" | "react-tsx")',
+      'Project template label ("server-ts" | "server-js" | "react" | "react-ciderjs" | "vue" | "vue-ciderjs" | "html-js")',
       "",
     )
     .option(
@@ -180,14 +180,30 @@ export async function main(): Promise<void> {
           packageManager = "npm";
         }
 
-        packageManager ||= await select<PackageManager>({
-          message: "Choice package manager what you want to use...",
-          choices: [
-            { name: "npm", value: "npm" },
-            { name: "pnpm", value: "pnpm" },
-            { name: "yarn", value: "yarn" },
-          ],
-        });
+        if (
+          packageManager == null ||
+          packageManager === ("" as PackageManager)
+        ) {
+          const selected = await select<PackageManager | null>({
+            message: "Choice package manager what you want to use...",
+            choices: [
+              { name: "npm", value: "npm" },
+              { name: "pnpm", value: "pnpm" },
+              { name: "yarn", value: "yarn" },
+              {
+                name: "skip",
+                value: null,
+                description: "Skip installation for now",
+              },
+            ],
+          });
+          if (selected === null) {
+            skipInstall = true;
+            packageManager = "npm";
+          } else {
+            packageManager = selected;
+          }
+        }
 
         const packageManagers: PackageManager[] = ["npm", "pnpm", "yarn"];
         if (!packageManagers.includes(packageManager)) {

--- a/template-projects/html-js/.clasp.json
+++ b/template-projects/html-js/.clasp.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/clasp.json",
+  "scriptId": "{{ input your script id of apps-script }}",
+  "rootDir": "dist"
+}

--- a/template-projects/html-js/.env
+++ b/template-projects/html-js/.env
@@ -1,0 +1,1 @@
+GAS_DEPLOYMENT_ID=input your deployment id

--- a/template-projects/html-js/README.md
+++ b/template-projects/html-js/README.md
@@ -1,0 +1,1 @@
+# Starter template for Google Apps Script webapp

--- a/template-projects/html-js/package.json
+++ b/template-projects/html-js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build:server": "rolldown -c && cpy server/*.json dist/",
-    "build:front": "tsc -b && vite build",
+    "build:front": "vite build",
     "build": "rimraf dist && pnpm run build:front && pnpm run build:server",
     "check": "biome check --write",
     "test": "vitest run --coverage",

--- a/template-projects/server-js/.clasp.json
+++ b/template-projects/server-js/.clasp.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/clasp.json",
+  "scriptId": "{{ input your script id of apps-script }}",
+  "rootDir": "dist"
+}

--- a/template-projects/vue-ciderjs/.github/workflows/appsscript.yml
+++ b/template-projects/vue-ciderjs/.github/workflows/appsscript.yml
@@ -1,0 +1,45 @@
+name: Publish to GoogleAppsScript
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on tags like v1.0.0, v0.1.2, etc.
+  workflow_dispatch: # Trigger manually
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Prebuild
+        run: pnpm run check && pnpm run test
+
+      - name: Build package
+        run: pnpm run build
+
+      - name: Restore clasp credentials
+        uses: ciderjs/clasp-auth@v0.1.3
+        with:
+          json: {{ secrets.CLASPRC_JSON }}
+
+      - name: Publish to AppsScript
+        run: pnpm run push


### PR DESCRIPTION
- Adds a skip option to the package manager selection prompt, allowing users to defer dependency installation.
- Updates the available template choices in the CLI's help message to be more accurate.
- Adds .clasp.json configuration files to the html-js and server-js templates.
- Adds a GitHub Actions workflow for publishing to the vue-ciderjs template.
- Bumps package version to 0.3.2.